### PR TITLE
화면 회전 시 발생하는 메일 탭 초기화 에러 수정

### DIFF
--- a/app/src/main/java/com/example/android_mail_17/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/com/example/android_mail_17/ui/activities/HomeActivity.kt
@@ -101,11 +101,6 @@ class HomeActivity : AppCompatActivity() {
         }
     }
 
-    private fun resetMailTab() {
-        binding.drawer.setCheckedItem(R.id.drawerPrimaryMenu)
-        // emailViewModel.setMailType(MailTypeEnum.PRIMARY)
-    }
-
     private fun changeFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragmentContainer, fragment)
@@ -113,28 +108,14 @@ class HomeActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        binding.bottomNavigation?.run {
-            when (selectedItemId) {
-                R.id.mailMenu -> {
-                    when (menuViewModel.selectedMailType.value) {
-                        MailTypeEnum.PRIMARY -> super.onBackPressed()
-                        else -> resetMailTab()
-                    }
+        when(menuViewModel.selectedTab.value) {
+            R.id.mailMenu -> {
+                when(menuViewModel.selectedMailType.value) {
+                    MailTypeEnum.PRIMARY -> super.onBackPressed()
+                    else -> menuViewModel.setSelectedMailType(MailTypeEnum.PRIMARY)
                 }
-                R.id.settingMenu -> selectedItemId = R.id.mailMenu
             }
-        }
-
-        binding.navigationRail?.run {
-            when (selectedItemId) {
-                R.id.mailMenu -> {
-                    when (menuViewModel.selectedMailType.value) {
-                        MailTypeEnum.PRIMARY -> super.onBackPressed()
-                        else -> resetMailTab()
-                    }
-                }
-                R.id.settingMenu -> selectedItemId = R.id.mailMenu
-            }
+            else -> menuViewModel.setSelectedTab(R.id.mailMenu)
         }
     }
 }

--- a/app/src/main/java/com/example/android_mail_17/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/com/example/android_mail_17/ui/activities/HomeActivity.kt
@@ -93,11 +93,21 @@ class HomeActivity : AppCompatActivity() {
 
     private fun setNavigationBarView() {
         NavigationBarView.OnItemSelectedListener { menuItem ->
+            if (menuItem.itemId == R.id.mailMenu) {
+                setMailTabDefault()
+            }
             menuViewModel.setSelectedTab(menuItem.itemId)
             true
         }.let { listener ->
             binding.bottomNavigation?.setOnItemSelectedListener(listener)
             binding.navigationRail?.setOnItemSelectedListener(listener)
+        }
+    }
+
+    private fun setMailTabDefault() {
+        menuViewModel.run {
+            setSelectedTab(R.id.mailMenu)
+            setSelectedMailType(MailTypeEnum.PRIMARY)
         }
     }
 
@@ -108,14 +118,14 @@ class HomeActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        when(menuViewModel.selectedTab.value) {
+        when (menuViewModel.selectedTab.value) {
             R.id.mailMenu -> {
-                when(menuViewModel.selectedMailType.value) {
+                when (menuViewModel.selectedMailType.value) {
                     MailTypeEnum.PRIMARY -> super.onBackPressed()
                     else -> menuViewModel.setSelectedMailType(MailTypeEnum.PRIMARY)
                 }
             }
-            else -> menuViewModel.setSelectedTab(R.id.mailMenu)
+            else -> setMailTabDefault()
         }
     }
 }

--- a/app/src/main/java/com/example/android_mail_17/ui/fragments/MailFragment.kt
+++ b/app/src/main/java/com/example/android_mail_17/ui/fragments/MailFragment.kt
@@ -12,12 +12,14 @@ import com.example.android_mail_17.databinding.FragmentMailBinding
 import com.example.android_mail_17.others.MailTypeEnum
 import com.example.android_mail_17.ui.activities.HomeActivity
 import com.example.android_mail_17.viewmodels.EmailViewModel
+import com.example.android_mail_17.viewmodels.MenuViewModel
 
 class MailFragment : Fragment() {
     private var _binding: FragmentMailBinding? = null
     private val binding: FragmentMailBinding get() = requireNotNull(_binding)
     private val adapter: MailListAdapter by lazy { MailListAdapter() }
     private val emailViewModel by activityViewModels<EmailViewModel>()
+    private val menuViewModel by activityViewModels<MenuViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -44,7 +46,7 @@ class MailFragment : Fragment() {
     }
 
     private fun setDataObserver() {
-        emailViewModel.mailType.observe(viewLifecycleOwner) { type ->
+        menuViewModel.selectedMailType.observe(viewLifecycleOwner) { type ->
             type?.run {
                 when (this) {
                     MailTypeEnum.PRIMARY -> binding.mailTypeView.text = getString(R.string.primary)

--- a/app/src/main/java/com/example/android_mail_17/viewmodels/EmailViewModel.kt
+++ b/app/src/main/java/com/example/android_mail_17/viewmodels/EmailViewModel.kt
@@ -12,14 +12,11 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 class EmailViewModel(application: Application) : AndroidViewModel(application) {
-    private var _mailType = MutableLiveData<MailTypeEnum>()
-    val mailType: MutableLiveData<MailTypeEnum> get() = _mailType
     private var _emailData = MutableLiveData<List<EmailData>>()
     val emailData: MutableLiveData<List<EmailData>> get() = _emailData
 
     init {
         fetchData(application)
-        setMailType(MailTypeEnum.PRIMARY)
     }
 
 
@@ -36,10 +33,6 @@ class EmailViewModel(application: Application) : AndroidViewModel(application) {
         } catch (e: Exception) {
             Log.e("userAssets", "${e.message}")
         }
-    }
-
-    fun setMailType(type: MailTypeEnum) {
-        mailType.postValue(type)
     }
 
     fun getFilteredDataByType(type: MailTypeEnum): List<EmailData>? {

--- a/app/src/main/java/com/example/android_mail_17/viewmodels/MenuViewModel.kt
+++ b/app/src/main/java/com/example/android_mail_17/viewmodels/MenuViewModel.kt
@@ -1,0 +1,23 @@
+package com.example.android_mail_17.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.android_mail_17.R
+import com.example.android_mail_17.others.MailTypeEnum
+
+class MenuViewModel : ViewModel() {
+    private var _selectedTab = MutableLiveData(R.id.mailMenu)
+    val selectedTab: LiveData<Int> get() = _selectedTab
+
+    private var _selectedMailType = MutableLiveData(MailTypeEnum.PRIMARY)
+    val mailType: LiveData<MailTypeEnum> get() = _selectedMailType
+
+    fun setSelectedTab(menu: Int) {
+        _selectedTab.value = menu
+    }
+
+    fun setMailType(type: MailTypeEnum) {
+        _selectedMailType.value = type
+    }
+}

--- a/app/src/main/java/com/example/android_mail_17/viewmodels/MenuViewModel.kt
+++ b/app/src/main/java/com/example/android_mail_17/viewmodels/MenuViewModel.kt
@@ -11,13 +11,13 @@ class MenuViewModel : ViewModel() {
     val selectedTab: LiveData<Int> get() = _selectedTab
 
     private var _selectedMailType = MutableLiveData(MailTypeEnum.PRIMARY)
-    val mailType: LiveData<MailTypeEnum> get() = _selectedMailType
+    val selectedMailType: LiveData<MailTypeEnum> get() = _selectedMailType
 
     fun setSelectedTab(menu: Int) {
         _selectedTab.value = menu
     }
 
-    fun setMailType(type: MailTypeEnum) {
+    fun setSelectedMailType(type: MailTypeEnum) {
         _selectedMailType.value = type
     }
 }


### PR DESCRIPTION
- MenuViewModel을 생성하여 NavigationBarView의 탭 정보와 drawer의 menu 정보를 관리하도록 수정
- 위 두 정보를 HomeActivity에서 관찰하여 값이 변경될 때 탭과 메뉴 변경, 프래그먼트 전환이 발생하도록 수정
- onBackPressed 메소드 수정
- 화면 이동 경로 초기화 로직 수정